### PR TITLE
Drop the table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,6 @@ We are constantly learning new things. This is a repo to share our learnings.
 TILs are short Markdown documents (a few sentences + example code) explaining a
 new concept, bit of syntax, command, or tip that we've learned.
 
-Browse TIL's by topic:
-
-* [Haskell](haskell)
-* [Ruby on Rails](rails)
-* [Ruby](ruby)
-* [vim](vim)
-
 To subscribe for updates,
 either watch this GitHub repo
 or follow [@thoughtbot](https://twitter.com/thoughtbot) on Twitter.


### PR DESCRIPTION
Maintaining the list of topics is an extra burden on those who
contribute things they've learned. Also, it's right above the rendered
README.md on GitHub.

Therefore, remove the table of contents from the README.