### PR TITLE
Add example with parallel assignment.

### DIFF
--- a/ruby/parallel-assignment.md
+++ b/ruby/parallel-assignment.md
@@ -1,0 +1,44 @@
+# Parallel assignment
+
+Ruby allows us to assign multiple variables on the same line. This is also
+called parallel assignment.
+
+```ruby
+a, b = 1, 2
+#=> [1, 2]
+a
+#=> 1
+b
+#=> 2
+```
+
+We can also use parallel assignment and the splat operator in combination to
+split the array into the head and tail. This is in particular useful if we want
+to [get all but the first element from an array](all-but-the-first-element-from-array.md).
+
+```ruby
+list = [1,2,3,4]
+#=> [1,2,3,4]
+head, *tail = list
+#=> [1,2,3,4]
+head
+#=> 1
+tail
+#=> [2,3,4]
+
+list # is not modified
+#=> [1,2,3,4]
+```
+
+### Empty arrays
+When using parallel assignment on an empty array, the tail will always return an
+array while the head will be `nil`.
+
+```ruby
+head, *tail = []
+#=> []
+head
+#=> nil
+tail
+#=> []
+```


### PR DESCRIPTION
Using a combination of parallel assignment and the splat operator, we can easily split the array into the head and tail. I think this example is worth including along with the other examples. It is not better than `#drop`, but it is simply just yet another way of doing it.