### PR TITLE
TIL: Java Number Format (+ Highlighting fix)

### DIFF
--- a/java/number-formatting.md
+++ b/java/number-formatting.md
@@ -17,12 +17,12 @@ Depending on your default Locale the currencyFormatter will format the number in
 
 ##### If you have a locale like `Locale.US` it will output:
 ```java
--12,345.12
+12,345.12
 ```
 
 ##### Or if you have a locale like `Locale.GERMANY`:
 ```java
--12.345,12
+12.345,12
 ```
 
 ### What about the Locale
@@ -32,5 +32,5 @@ Using `Locale.getDefault()` allows you to get the System default, so it depends 
 Here is an in-browser example that you can try: [Coding Ground Example]
 Steps to run: compile and execute.
 
-[Coding Ground Example]:http://goo.gl/wq7aa5
+[Coding Ground Example]:http://www.tutorialspoint.com/compile_java_online.php?PID=0Bw_CjBb95KQMbHZ0NWc1OVRONkE
 [Documentation for Locale]:http://docs.oracle.com/javase/7/docs/api/java/util/Locale.html

--- a/java/number-formatting.md
+++ b/java/number-formatting.md
@@ -1,7 +1,7 @@
 # NumberFormatting 
 
 ## Assignment
-How can someone format a number easily, without thinking too much about how the format would look like in a specific locale. Let's say we want to format: `12345.124` that it will look something like: `12,345.12` of course special characters according to the locale, but how can this be done?
+Format a number for a specific locale. For example, the number 12345.124 should be formatted as `12,345.12` in the USA locale, but `12.345,78` in the German locale.
 
 ## Solution
 ```java
@@ -16,7 +16,7 @@ System.out.println(currencyFormatter.format(123456.12));
 Depending on your default Locale the currencyFormatter will format the number in the right way for you.
 
 ##### Will output:
-```
+```java
 -123,456.78
 ```
 
@@ -26,6 +26,7 @@ Depending on your default Locale the currencyFormatter will format the number in
 ```
 
 ### Executable Online Java Example:
-I prepared an online java testing for you here: [Coding Ground Example] All you have to do is press: compile and execute. Hope you like it.
+Here is an in-browser example that you can try: [Coding Ground Example]
+Steps to run: compile and execute.
 
 [Coding Ground Example]:http://goo.gl/wq7aa5

--- a/java/number-formatting.md
+++ b/java/number-formatting.md
@@ -10,10 +10,10 @@ DecimalFormat currencyFormatter = (DecimalFormat) NumberFormat.getInstance(Local
 currencyFormatter.setMaximumFractionDigits(2);
 currencyFormatter.setMinimumFractionDigits(2);
 
-System.out.println(currencyFormatter.format(123456.12));
+System.out.println(currencyFormatter.format(12345.12));
 ```
 
-Depending on your default Locale the currencyFormatter will format the number in the right way for you.
+Depending on your default Locale the currencyFormatter will format the number the right way.
 
 ##### If you have a locale like `Locale.US` it will output:
 ```java

--- a/java/number-formatting.md
+++ b/java/number-formatting.md
@@ -1,7 +1,7 @@
 # NumberFormatting 
 
 ## Assignment
-Format a number for a specific locale. For example, the number 12345.124 should be formatted as `12,345.12` in the USA locale, but `12.345,78` in the German locale.
+Format a number for a specific locale. For example, the number 12345.123 should be formatted as `12,345.12` in the USA locale, but `12.345,12` in the German locale.
 
 ## Solution
 ```java
@@ -17,12 +17,12 @@ Depending on your default Locale the currencyFormatter will format the number in
 
 ##### If you have a locale like `Locale.US` it will output:
 ```java
--123,456.78
+-12,345.12
 ```
 
 ##### Or if you have a locale like `Locale.GERMANY`:
 ```java
--123.456,78
+-12.345,12
 ```
 
 ### What about the Locale

--- a/java/number-formatting.md
+++ b/java/number-formatting.md
@@ -15,7 +15,7 @@ System.out.println(currencyFormatter.format(123456.12));
 
 Depending on your default Locale the currencyFormatter will format the number in the right way for you.
 
-##### Will output:
+##### If you have a locale like `Locale.US` it will output:
 ```java
 -123,456.78
 ```
@@ -25,8 +25,12 @@ Depending on your default Locale the currencyFormatter will format the number in
 -123.456,78
 ```
 
+### What about the Locale
+Using `Locale.getDefault()` allows you to get the System default, so it depends on your settings. You can test it for other Locale's by using fixed locale values like: `Locale.GERMAN`or `Locale.US` for USA. You also can find the Local according to the `language`/`country` by using `Locale(String language)` or `Locale(String language, String country)`. More details can be found here: [Documentation for Locale].
+
 ### Executable Online Java Example:
 Here is an in-browser example that you can try: [Coding Ground Example]
 Steps to run: compile and execute.
 
 [Coding Ground Example]:http://goo.gl/wq7aa5
+[Documentation for Locale]:http://docs.oracle.com/javase/7/docs/api/java/util/Locale.html

--- a/java/number-formatting.md
+++ b/java/number-formatting.md
@@ -1,0 +1,31 @@
+# NumberFormatting 
+
+## Assignment
+How can someone format a number easily, without thinking too much about how the format would look like in a specific locale. Let's say we want to format: `12345.124` that it will look something like: `12,345.12` of course special charakters according to the locale, but how can this be done?
+
+## Solution
+```java
+DecimalFormat currencyFormatter = (DecimalFormat) NumberFormat.getInstance(Locale.getDefault());
+
+currencyFormatter.setMaximumFractionDigits(2);
+currencyFormatter.setMinimumFractionDigits(2);
+
+System.out.println(currencyFormatter.format(123456.12));
+```
+
+Depending on your default Locale the currencyFormatter will format the number in the right way for you.
+
+##### Will output:
+```
+-123,456.78
+```
+
+##### Or if you have a locale like `Locale.GERMANY`:
+```java
+-123.456,78
+```
+
+### Executable Online Java Example:
+I prepared an online java testing for you here: [Coding Ground Example] All you have to do is press: compile and execute. Hope you like it.
+
+[Coding Ground Example]:http://goo.gl/wq7aa5

--- a/java/number-formatting.md
+++ b/java/number-formatting.md
@@ -1,7 +1,7 @@
 # NumberFormatting 
 
 ## Assignment
-How can someone format a number easily, without thinking too much about how the format would look like in a specific locale. Let's say we want to format: `12345.124` that it will look something like: `12,345.12` of course special charakters according to the locale, but how can this be done?
+How can someone format a number easily, without thinking too much about how the format would look like in a specific locale. Let's say we want to format: `12345.124` that it will look something like: `12,345.12` of course special characters according to the locale, but how can this be done?
 
 ## Solution
 ```java

--- a/testing/capybara-all-does-not-return-array.md
+++ b/testing/capybara-all-does-not-return-array.md
@@ -6,7 +6,7 @@ many of the most used methods on `Array` such as `[]`.
 
 Given the following HTML:
 
-```ruby
+```html
 <body>
   <p>Some content</p>
   <p>Other content</p>


### PR DESCRIPTION
1. Changed syntax-highlighting for HTML document to HTML
2. Added folder Java
3. Added Number Formatting because that bugs a lot people.