### PR TITLE
Share through @upcase, not @thoughtbot?

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,4 +12,4 @@ Open a pull request for review.
 
 After merging into master,
 [Buffer](https://bufferapp.com) a tweet from the
-[@thoughtbot](https://twitter.com/thoughtbot) account.
+[@upcase](https://twitter.com/upcase) account.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,16 @@ TILs are short Markdown documents (a few sentences + example code) explaining a
 new concept, bit of syntax, command, or tip that we've learned.
 
 To subscribe for updates,
-either watch this GitHub repo
-or follow [@thoughtbot](https://twitter.com/thoughtbot) on Twitter.
+watch this GitHub repo
+or follow [@upcase] on Twitter.
+
+[@upcase]: https://twitter.com/upcase
+
+If you like this repo,
+you might also like
+[Upcase]'s programming exercises and videos.
+
+[Upcase]: https://upcase.com?utm_source=til
 
 License
 -------


### PR DESCRIPTION
Partially inspired by [this tweet], I'm wondering if it would help distinguish
TIL content in the @thoughtbot Twitter feed if it came from @upcase, our
differently-colored learning brand, instead of being prefixed as "TIL: ".

[this tweet]: https://twitter.com/bufo_alvarius/status/559969798353080321