### PR TITLE
TIL how to yank words to registers in VIM

### DIFF
--- a/vim/yanking-text-to-register.md
+++ b/vim/yanking-text-to-register.md
@@ -1,10 +1,10 @@
 # Yanking text to register
 
-Yanking and deleting text will save the text to the same unamed register. Which means every time you delete a word, your 
+Yanking and deleting text will save the text to the same unnamed register. Which means every time you delete a word, your 
 yanked word will be overwritten. Which caused me endless amounts of frustration when I accidentally deleted a word and had to
 remember what I yanked earlier.
 
-I learned that you can specify a register to save your yanked word to by prepending your yank command with `"a`. Where a
+I learned that you can specify a register to save your yanked word to by prepending your yank command with `"a`. Where `a`
 is a register. There are a number of different registers which do different things. If you want to learn more read vim's [register
 documentation](http://vimdoc.sourceforge.net/htmldoc/change.html#registers).
 

--- a/vim/yanking-text-to-register.md
+++ b/vim/yanking-text-to-register.md
@@ -5,7 +5,7 @@ yanked word will be overwritten. This caused me endless amounts of frustration w
 remember what I yanked earlier.
 
 I learned that you can specify a register to save your yanked word to by prepending your yank command with `"a`. Where `a`
-is a register. There are a number of different registers which do different things. If you want to learn more read vim's [register
+is a register. There are a number of different registers which do different things. If you want to learn more read VIM's [register
 documentation](http://vimdoc.sourceforge.net/htmldoc/change.html#registers).
 
 An example usage is:
@@ -18,4 +18,20 @@ word by:
 `"ap`
 
 Even after deleting various words in your file. Your yanked word will always be in register `a`.
-The vim wiki has more details on [Replacing a word with yanked text](http://vim.wikia.com/wiki/Replace_a_word_with_yanked_text).
+The VIM wiki has more details on [Replacing a word with yanked text](http://vim.wikia.com/wiki/Replace_a_word_with_yanked_text).
+
+# More on Registers
+
+[Zamith](https://github.com/zamith) mentioned using the null register which is the black hole register. Whatever goes in there is gone forever. This is his example:
+
+```
+yw       # Save a word to the unnamed register
+"_dw     # Delete a word and "save" to the _ register
+```
+  
+If you then try to `"_p`, nothing will happen, because the `_` register never saves anything. The unnamed register (which is mentioned above) can also be set to the clipboard. Which is useful for copying content outside of VIM.
+
+`set clipboard=unnamed`
+  
+Another tip is to use the `:registers` command in VIM. This command will show you what is in each register. Thanks [iwz](https://github.com/iwz) for the tip!
+

--- a/vim/yanking-text-to-register.md
+++ b/vim/yanking-text-to-register.md
@@ -1,0 +1,21 @@
+# Yanking text to register
+
+Yanking and deleting text will save the text to the same unamed register. Which means every time you delete a word, your 
+yanked word will be overwritten. Which caused me endless amounts of frustration when I accidentally deleted a word and had to
+remember what I yanked earlier.
+
+I learned that you can specify a register to save your yanked word to by prepending your yank command with `"a`. Where a
+is a register. There are a number of different registers which do different things. If you want to learn more read vim's [register
+documentation](http://vimdoc.sourceforge.net/htmldoc/change.html#registers).
+
+An example usage is:
+
+`"ayw`
+
+This will save the yanked word to the register a. After deleting various things in your file you can always paste your yanked
+word by:
+
+`"ap`
+
+Even after deleting various words in your file. Your yanked word will always be in register `a`.
+The vim wiki has more details on [Replacing a word with yanked text](http://vim.wikia.com/wiki/Replace_a_word_with_yanked_text).

--- a/vim/yanking-text-to-register.md
+++ b/vim/yanking-text-to-register.md
@@ -1,7 +1,7 @@
 # Yanking text to register
 
 Yanking and deleting text will save the text to the same unnamed register. Every time you delete a word, your 
-yanked word will be overwritten. Which caused me endless amounts of frustration when I accidentally deleted a word and had to
+yanked word will be overwritten. This caused me endless amounts of frustration when I accidentally deleted a word and had to
 remember what I yanked earlier.
 
 I learned that you can specify a register to save your yanked word to by prepending your yank command with `"a`. Where `a`

--- a/vim/yanking-text-to-register.md
+++ b/vim/yanking-text-to-register.md
@@ -1,6 +1,6 @@
 # Yanking text to register
 
-Yanking and deleting text will save the text to the same unnamed register. Which means every time you delete a word, your 
+Yanking and deleting text will save the text to the same unnamed register. Every time you delete a word, your 
 yanked word will be overwritten. Which caused me endless amounts of frustration when I accidentally deleted a word and had to
 remember what I yanked earlier.
 
@@ -12,7 +12,7 @@ An example usage is:
 
 `"ayw`
 
-This will save the yanked word to the register a. After deleting various things in your file you can always paste your yanked
+This will save the yanked word to the register `a`. After deleting various things in your file you can always paste your yanked
 word by:
 
 `"ap`


### PR DESCRIPTION
I had issues with my deleted words always replacing my yanked word. Today I finally found out that you can save a yanked word to a certain register. This is just a basic way to ensure that your yanked text isn't overwritten by other yanks or deletes.