### PR TITLE
Remove the mention of force push and add note about not rebasing already pushed commits

### DIFF
--- a/git/split-up-a-commit.md
+++ b/git/split-up-a-commit.md
@@ -50,3 +50,7 @@ Keep in mind that you might have to force push your branch to `origin`,
 depending on whether or not your revised commits have been pushed.
 
     $ git push origin my-branch-name --force
+
+However, it is always recommended that you do not rebase commits that are already
+pushed to a public repository.
+Read more about [The Perils of Rebasing](http://git-scm.com/book/en/v2/Git-Branching-Rebasing#The-Perils-of-Rebasing)

--- a/git/split-up-a-commit.md
+++ b/git/split-up-a-commit.md
@@ -46,11 +46,10 @@ If all went well, your branch's history will be re-written.
     274ac0e Move components
     # ...
 
-Keep in mind that you might have to force push your branch to `origin`,
-depending on whether or not your revised commits have been pushed.
+Now you can push your changes.
 
-    $ git push origin my-branch-name --force
+    $ git push origin my-branch-name
 
-However, it is always recommended that you do not rebase commits that are already
+It is always recommended that you do not rebase commits that are already
 pushed to a public repository.
 Read more about [The Perils of Rebasing](http://git-scm.com/book/en/v2/Git-Branching-Rebasing#The-Perils-of-Rebasing)


### PR DESCRIPTION
I think it is good if we add a note about the caveats of rewriting history that is already pushed. I have added a footnote with a link to the related ProGit section.
