### PR TITLE
Add contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,21 @@ For help submitting, please review our [Git Commits for Non-Git Users](/GitCommi
 After merging into master,
 [Buffer](https://bufferapp.com) a tweet from the
 [@upcase](https://twitter.com/upcase) account.
+
+
+## Writing a good a TIL
+
+TIL's should be a focused and concise piece of knowledge that's interesting and
+worth sharing with others.
+
+Here's some guidelines on how to write a great TIL:
+
+* Avoid writing more than 60 lines of content.
+* Avoid writing more than 2 examples.
+* Avoid going into too much detail.
+* Avoid writing TIL's that explicitly violate [our guides].
+
+If you find TIL straying from these guidelines consider narrowing the scope of
+your TIL or writing a blog post on the subject.
+
+[our guides]: https://github.com/thoughtbot/guides


### PR DESCRIPTION
Many PR's in the TIL repo lately have been more like micro-blog posts
rather than TIL's. This adds a "Contributing a TIL" section to help
define what a TIL is and what makes a good TIL.