### PR TITLE
replace `run-scripts` with `run`

### DIFF
--- a/javascript/npm-scripts.md
+++ b/javascript/npm-scripts.md
@@ -30,7 +30,7 @@ not directly supported.
 
 To execute the `build` script, run:
 
-      $ npm run-script build
+      $ npm run build
 
 It is also important to note that a `prebuild` hook *would not* fire before the
 `build` script's execution.


### PR DESCRIPTION
Feel free to reject this PR, but it's seemingly less disappointing to read that i only have to type `run` vs `run-script`. i'm _that_ lazy. Maybe others would benefit from this realness?
